### PR TITLE
feat: Implement functionality to download tweet replies

### DIFF
--- a/src/xtract/api/client.py
+++ b/src/xtract/api/client.py
@@ -460,14 +460,12 @@ def download_x_post(
         # Save raw response for the main tweet
         raw_file = os.path.join(tweet_dir, "raw_response.json")
         logger.debug(f"Saving raw response to: {raw_file}")
-    save_json(data, raw_file) # 'data' contains the full response for the main tweet
-        print(f"Raw response saved to: {raw_file}")
+        save_json(data, raw_file) # 'data' contains the full response for the main tweet
 
-    # Save structured tweet data (now including replies)
+        # Save structured tweet data (now including replies)
         json_file = os.path.join(tweet_dir, "tweet.json")
         logger.debug(f"Saving structured JSON to: {json_file}")
-    save_json(main_post.to_dict(), json_file) # Use main_post here
-        print(f"Structured JSON saved to: {json_file}")
+        save_json(main_post.to_dict(), json_file) # Use main_post here
 
     logger.info(f"Successfully downloaded and processed tweet ID: {tweet_id} (Main Post ID: {main_post.tweet_id})")
     return main_post

--- a/src/xtract/api/client.py
+++ b/src/xtract/api/client.py
@@ -7,7 +7,7 @@ import json
 import logging
 import requests
 from datetime import datetime
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any, Tuple, List
 from urllib.parse import urlparse
 
 from xtract.api.errors import APIError, TokenExpiredError
@@ -149,6 +149,133 @@ def fetch_tweet_data(tweet_id: str, headers: Dict[str, str]) -> Dict[str, Any]:
         raise APIError(f"Failed to fetch tweet {tweet_id}: {e}")
 
 
+def fetch_tweet_replies(tweet_id: str, headers: Dict[str, str]) -> List[Dict[str, Any]]:
+    """
+    Fetch raw reply data for a given tweet ID from the X API.
+    This function focuses on fetching the first batch of replies and does not implement pagination.
+
+    Args:
+        tweet_id: ID of the tweet for which to fetch replies.
+        headers: Headers for the API request, including authentication.
+
+    Returns:
+        List[Dict[str, Any]]: A list of raw reply tweet objects. Returns an empty list if
+                              no replies are found or in case of an error during parsing.
+
+    Raises:
+        TokenExpiredError: If the API returns a 403 error (typically means token expired).
+        APIError: If the API request fails for other reasons.
+    """
+    logger.info(f"Attempting to fetch replies for tweet ID: {tweet_id}")
+
+    variables = {
+        "focalTweetId": tweet_id,
+        "withReplies": True,  # Key to fetch replies
+        "withCommunity": False,
+        "includePromotedContent": False,
+        "withVoice": False,
+        # Adding cursor might be necessary for pagination, but omitted for simplicity now
+        # "cursor": None,
+    }
+    params = {
+        "variables": json.dumps(variables),
+        "features": json.dumps(DEFAULT_FEATURES),
+        "fieldToggles": json.dumps(DEFAULT_FIELD_TOGGLES), # Ensure this matches other calls
+    }
+
+    try:
+        logger.debug(f"Sending request to {TWEET_DATA_URL} for replies to tweet ID: {tweet_id}")
+        response = requests.get(TWEET_DATA_URL, headers=headers, params=params)
+
+        if response.status_code == 403:
+            error_msg = f"Token expired or invalid (403 Forbidden) while fetching replies for tweet {tweet_id}: {response.text}"
+            logger.warning(error_msg)
+            raise TokenExpiredError(error_msg)
+
+        response.raise_for_status()
+        raw_json_response = response.json()
+        logger.debug(f"Successfully received response for replies to tweet ID: {tweet_id}")
+
+    except requests.HTTPError as e:
+        logger.error(f"HTTP error fetching replies for tweet {tweet_id}: {e}")
+        raise APIError(f"HTTP error fetching replies for tweet {tweet_id}: {e}")
+    except requests.RequestException as e:
+        logger.error(f"Request exception fetching replies for tweet {tweet_id}: {e}")
+        raise APIError(f"Request exception fetching replies for tweet {tweet_id}: {e}")
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to decode JSON response when fetching replies for {tweet_id}: {e}")
+        raise APIError(f"Failed to decode JSON response for replies to {tweet_id}: {e}")
+
+    replies_data = []
+    try:
+        # Speculative path to replies based on common API patterns for threaded conversations
+        # The actual path might differ and need inspection of a live API response.
+        # Common structures involve 'instructions' which contain 'entries' or 'items'.
+        instructions = raw_json_response.get("data", {}).get("threaded_conversation_with_replies", {}).get("instructions", [])
+        if not instructions: # Fallback for slightly different structures seen in some API versions
+            instructions = raw_json_response.get("data", {}).get("tweetResult", {}).get("result", {}).get("tweet", {}).get("conversation_thread",{}).get("instructions",[])
+
+        entries = []
+        for instruction in instructions:
+            # Entries can be directly under instruction or under typedInstruction
+            if "entries" in instruction:
+                entries.extend(instruction.get("entries", []))
+            elif instruction.get("type") == "TimelineAddEntries" or "addEntries" in instruction: # Common instruction type
+                 entries.extend(instruction.get("addEntries", {}).get("entries", []))
+
+
+        if not entries:
+            logger.warning(f"No 'entries' found in the expected path for tweet {tweet_id} replies. Full response snippet: {str(raw_json_response)[:500]}")
+            return []
+
+        for entry in entries:
+            # Entries can have different structures. We are looking for those containing tweet data.
+            # The 'entryId' often indicates the type of item, e.g., 'tweet-<id>', 'conversationthread-<id>', 'cursor-top', 'cursor-bottom'.
+            entry_id_str = entry.get("entryId", "")
+
+            if "tweet-" in entry_id_str or "conversationthread-" in entry_id_str : # Check if it's likely a tweet entry
+                content = entry.get("content", {})
+                item_content = content.get("itemContent", {})
+                if not item_content and "items" in content: # Another possible structure where items are nested
+                    for item_entry in content.get("items", []):
+                        item_content_candidate = item_entry.get("item",{}).get("itemContent",{})
+                        if item_content_candidate.get("tweet_results",{}).get("result"):
+                            item_content = item_content_candidate
+                            break # Take the first valid one
+
+                tweet_result = item_content.get("tweet_results", {}).get("result")
+
+                if not tweet_result: # Try another common path for conversation items (e.g. within "item" key)
+                     tweet_result = content.get("items", [{}])[0].get("item", {}).get("itemContent", {}).get("tweet_results", {}).get("result")
+
+
+                if tweet_result:
+                    # Ensure it's a valid tweet object (e.g., has 'legacy' data and is not the focal tweet itself)
+                    # The API might return the focal tweet as part of the conversation thread.
+                    if tweet_result.get("legacy") and tweet_result.get("rest_id") != tweet_id:
+                        logger.debug(f"Found reply: {tweet_result.get('rest_id')} for focal tweet {tweet_id}")
+                        replies_data.append(tweet_result)
+                    elif tweet_result.get("rest_id") == tweet_id:
+                        logger.debug(f"Skipping entry for focal tweet {tweet_id} found within replies.")
+                else:
+                    logger.debug(f"Entry {entry_id_str} did not contain tweet_results.result in expected location. Keys: {item_content.keys()}")
+            elif not ("cursor-top" in entry_id_str or "cursor-bottom" in entry_id_str or "who-to-follow" in entry_id_str or "profile-spotlight" in entry_id_str):
+                 logger.debug(f"Skipping non-tweet/non-conversationthread entry: {entry_id_str}")
+
+
+    except Exception as e:
+        logger.warning(f"Error parsing replies for tweet {tweet_id}: {e}. Response snippet: {str(raw_json_response)[:500]}")
+        # Return whatever was parsed so far, or an empty list
+        return replies_data
+
+    if not replies_data:
+        logger.info(f"No replies found or extracted for tweet ID: {tweet_id}")
+    else:
+        logger.info(f"Successfully extracted {len(replies_data)} replies for tweet ID: {tweet_id}")
+
+    return replies_data
+
+
 def download_x_post(
     post_identifier: str,
     output_dir: str = None,
@@ -247,26 +374,100 @@ def download_x_post(
 
     # Process the tweet data
     logger.debug("Processing retrieved tweet data")
-    tweet = data.get("data", {}).get("tweetResult", {}).get("result", {})
-    legacy = tweet.get("legacy", {})
-    user = tweet.get("core", {}).get("user_results", {}).get("result", {}).get("legacy", {})
-    note_tweet = tweet.get("note_tweet", {}).get("note_tweet_results", {}).get("result", {})
+    tweet_result_data = data.get("data", {}).get("tweetResult", {}).get("result", {})
 
-    logger.debug("Creating Post object from API data")
-    post = Post.from_api_data(tweet, legacy, user, note_tweet)
+    if not tweet_result_data or not tweet_result_data.get("rest_id"):
+        logger.error(f"Main tweet data is missing 'rest_id' or is malformed for original ID: {tweet_id}. Response snippet: {str(data)[:500]}")
+        # Depending on desired strictness, one might return None or raise an error here.
+        # For now, we'll log and attempt to proceed if possible, or let it fail at Post.from_api_data.
+        # If tweet_result_data is empty, Post.from_api_data will likely fail, which is acceptable.
+
+    # Fetch replies
+    raw_replies = []
+    try:
+        logger.info(f"Fetching replies for tweet ID: {tweet_id}")
+        # Use the same headers, which include the guest token if applicable
+        raw_replies = fetch_tweet_replies(tweet_id, headers)
+        if raw_replies:
+            logger.info(f"Successfully fetched {len(raw_replies)} raw replies for tweet ID: {tweet_id}")
+        else:
+            logger.info(f"No replies found or fetched for tweet ID: {tweet_id}")
+    except APIError as e: # Includes TokenExpiredError
+        logger.warning(f"Could not fetch replies for tweet ID {tweet_id}: {e}. Continuing without replies.")
+        # Optional: could trigger a retry or token refresh here if desired, but fetch_tweet_replies already has some handling
+    except Exception as e:
+        logger.error(f"An unexpected error occurred while fetching replies for tweet ID {tweet_id}: {e}. Continuing without replies.")
+
+    reply_objects = []
+    if raw_replies:
+        logger.debug(f"Processing {len(raw_replies)} raw replies into Post objects for tweet ID: {tweet_id}")
+        for i, raw_reply_data in enumerate(raw_replies):
+            try:
+                if not raw_reply_data or not raw_reply_data.get("rest_id"):
+                    logger.warning(f"Skipping reply {i+1} for tweet {tweet_id} due to missing 'rest_id' or malformed data: {str(raw_reply_data)[:200]}")
+                    continue
+
+                logger.debug(f"Processing reply tweet ID: {raw_reply_data.get('rest_id')}")
+                # The raw_reply_data itself is the 'tweet' part for Post.from_api_data
+                reply_tweet_api_data = raw_reply_data
+                reply_legacy_data = raw_reply_data.get("legacy", {})
+                reply_user_data = raw_reply_data.get("core", {}).get("user_results", {}).get("result", {}).get("legacy", {})
+                # Check if user_results.result itself is the user data, common in some API responses
+                if not reply_user_data and raw_reply_data.get("core", {}).get("user_results", {}).get("result"):
+                    reply_user_data = raw_reply_data.get("core", {}).get("user_results", {}).get("result") # No .legacy here
+
+                reply_note_tweet_data = raw_reply_data.get("note_tweet", {}).get("note_tweet_results", {}).get("result", {})
+
+                # Basic check to ensure essential data parts are present
+                if not reply_legacy_data:
+                    logger.warning(f"Skipping reply {raw_reply_data.get('rest_id')} due to missing 'legacy' data.")
+                    continue
+                if not reply_user_data: # User data is essential
+                     logger.warning(f"Skipping reply {raw_reply_data.get('rest_id')} due to missing 'user' data (core.user_results.result.legacy).")
+                     continue
+
+
+                reply_post_obj = Post.from_api_data(
+                    tweet=reply_tweet_api_data,
+                    legacy=reply_legacy_data,
+                    user=reply_user_data,
+                    note_tweet=reply_note_tweet_data
+                )
+                reply_objects.append(reply_post_obj)
+            except Exception as e:
+                logger.error(f"Failed to process reply {i+1} (ID: {raw_reply_data.get('rest_id', 'unknown')}) for tweet {tweet_id}: {e}. Reply data snippet: {str(raw_reply_data)[:200]}")
+                # Continue to the next reply
+
+    # Definitions for the main post
+    legacy = tweet_result_data.get("legacy", {})
+    user = tweet_result_data.get("core", {}).get("user_results", {}).get("result", {}).get("legacy", {})
+    # Check if user_results.result itself is the user data
+    if not user and tweet_result_data.get("core", {}).get("user_results", {}).get("result"):
+        user = tweet_result_data.get("core", {}).get("user_results", {}).get("result")
+
+
+    note_tweet = tweet_result_data.get("note_tweet", {}).get("note_tweet_results", {}).get("result", {})
+
+    logger.debug("Creating main Post object from API data")
+    # Use tweet_result_data for the 'tweet' argument as it's the specific result for the main tweet
+    main_post = Post.from_api_data(tweet_result_data, legacy, user, note_tweet)
+
+    if reply_objects:
+        main_post.replies = reply_objects
+        logger.info(f"Successfully processed and attached {len(reply_objects)} replies to main post ID: {main_post.tweet_id}")
 
     if save_raw_response_to_file and tweet_dir:
-        # Save raw response
+        # Save raw response for the main tweet
         raw_file = os.path.join(tweet_dir, "raw_response.json")
         logger.debug(f"Saving raw response to: {raw_file}")
-        save_json(data, raw_file)
+    save_json(data, raw_file) # 'data' contains the full response for the main tweet
         print(f"Raw response saved to: {raw_file}")
 
-        # Save structured tweet data
+    # Save structured tweet data (now including replies)
         json_file = os.path.join(tweet_dir, "tweet.json")
         logger.debug(f"Saving structured JSON to: {json_file}")
-        save_json(post.to_dict(), json_file)
+    save_json(main_post.to_dict(), json_file) # Use main_post here
         print(f"Structured JSON saved to: {json_file}")
 
-    logger.info(f"Successfully downloaded and processed tweet ID: {tweet_id}")
-    return post
+    logger.info(f"Successfully downloaded and processed tweet ID: {tweet_id} (Main Post ID: {main_post.tweet_id})")
+    return main_post

--- a/src/xtract/models/post.py
+++ b/src/xtract/models/post.py
@@ -72,6 +72,7 @@ class Post:
     user_details: UserDetails
     post_data: PostData
     quoted_tweet: Optional["Post"] = None
+    replies: Optional[List["Post"]] = None
 
     @classmethod
     def from_api_data(
@@ -177,5 +178,9 @@ class Post:
         if self.quoted_tweet:
             logger.debug("Including quoted tweet in dictionary")
             result["quoted_tweet"] = self.quoted_tweet.to_dict()
+
+        if self.replies:
+            logger.debug(f"Including replies in dictionary for tweet ID: {self.tweet_id}")
+            result["replies"] = [reply.to_dict() for reply in self.replies]
 
         return result


### PR DESCRIPTION
This change enhances the X post extraction capabilities by adding the ability to download replies to a given tweet.

Key changes:

- Updated `Post` model (`src/xtract/models/post.py`):
    - Added an optional `replies` field (List[Post]) to store reply tweets.
    - Modified `to_dict` to include serialized replies in the output.

- Enhanced API client (`src/xtract/api/client.py`):
    - Introduced `fetch_tweet_replies` function to retrieve replies for a tweet using a speculative approach to the X API (GraphQL). This function includes parsing logic to extract reply tweets from the conversation thread.
    - Modified `download_x_post` to:
        - Call `fetch_tweet_replies` after fetching the main tweet.
        - Process raw reply data into `Post` objects. - Attach the list of reply `Post` objects to the `replies` attribute of the main `Post` object. - Ensure replies are included in the saved JSON output if `save_raw_response_to_file` is enabled.

- Added Tests:
    - `tests/test_post.py`: New tests verify that the `Post` model correctly handles the `replies` field and its serialization.
    - `tests/test_client.py`: New tests for `fetch_tweet_replies` (mocking API success, no replies, and error scenarios) and for `download_x_post` to ensure replies are fetched and integrated correctly into the main post and that failures are handled gracefully.

The implementation of `fetch_tweet_replies` is based on current understanding of how the X API might structure conversation data and may require future adjustments if the API changes or detailed information becomes available.